### PR TITLE
Fix moe h100

### DIFF
--- a/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/default_fpA_intB_traits.h
+++ b/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/default_fpA_intB_traits.h
@@ -117,6 +117,31 @@ public:
 
     using Operator = typename LayoutDetails::Operator;
 };
+// ======================= Ampere Traits ==============================
+template<typename TypeA, typename TypeB>
+struct MixedGemmArchTraits<
+    TypeA,
+    TypeB,
+    cutlass::arch::Sm90,
+    typename cutlass::platform::enable_if<cutlass::platform::is_same<TypeA, cutlass::half_t>::value
+                                          || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type> {
+private:
+    using LayoutDetails = LayoutDetailsB<TypeB, cutlass::arch::Sm90>;
+
+public:
+    static constexpr int ThreadblockK = LayoutDetails::ThreadblockK;
+
+    using OperatorClass = cutlass::arch::OpClassTensorOp;
+    using AccType       = float;
+    using LayoutB       = typename LayoutDetails::Layout;
+
+    static constexpr int ElementsPerAccessA = 128 / cutlass::sizeof_bits<TypeA>::value;
+    static constexpr int ElementsPerAccessB = LayoutDetails::ElementsPerAccess;
+    static constexpr int ElementsPerAccessC = 128 / cutlass::sizeof_bits<TypeA>::value;
+    using InstructionShape                  = cutlass::gemm::GemmShape<16, 8, 16>;
+
+    using Operator = typename LayoutDetails::Operator;
+};
 
 }  // namespace kernel
 }  // namespace gemm

--- a/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/gemm_moe_problem_visitor.h
+++ b/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/gemm_moe_problem_visitor.h
@@ -56,7 +56,7 @@ template<typename ThreadblockShape,
          int               ThreadCount,
          bool              Transposed = false>
 struct GemmMoeProblemVisitor:
-    public MoeProblemVisitor<detail::GemmGroupedProblemSizeHelper<Transposed>,
+    public MoeProblemVisitor<detail::GemmGroupedProblemSizeHelper<ThreadblockShape, Transposed>,
                              ThreadblockShape,
                              GroupScheduleMode_,
                              PrefetchTileCount,
@@ -64,7 +64,7 @@ struct GemmMoeProblemVisitor:
 
     static bool const kTransposed = Transposed;
 
-    using ProblemSizeHelper = detail::GemmGroupedProblemSizeHelper<Transposed>;
+    using ProblemSizeHelper = detail::GemmGroupedProblemSizeHelper<ThreadblockShape, Transposed>;
     using Base =
         MoeProblemVisitor<ProblemSizeHelper, ThreadblockShape, GroupScheduleMode_, PrefetchTileCount, ThreadCount>;
     using Params        = typename Base::Params;

--- a/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h
+++ b/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h
@@ -518,10 +518,8 @@ public:
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 900)
         static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
         KernelRunner<compile_needed>::run_kernel(params, shared_storage);#elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-        // TODO Update the arch to Sm90 once CUTLASS hopper specialisations are available
         static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
-        // TODO Update the arch to Sm90 once CUTLASS hopper specialisations are available
         static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
         KernelRunner<compile_needed>::run_kernel(params, shared_storage);
 #else

--- a/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h
+++ b/dskernels/ft_gemm/gemm_variants/cutlass_extensions/gemm/kernel/moe_cutlass_kernel.h
@@ -517,6 +517,12 @@ public:
         KernelRunner<compile_needed>::run_kernel(params, shared_storage);
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 900)
         static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
+        KernelRunner<compile_needed>::run_kernel(params, shared_storage);#elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+        // TODO Update the arch to Sm90 once CUTLASS hopper specialisations are available
+        static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
+#elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+        // TODO Update the arch to Sm90 once CUTLASS hopper specialisations are available
+        static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
         KernelRunner<compile_needed>::run_kernel(params, shared_storage);
 #else
         CUTLASS_NOT_IMPLEMENTED();

--- a/dskernels/ft_gemm/gemm_variants/moe_gemm/moe_gemm_kernels_template.h
+++ b/dskernels/ft_gemm/gemm_variants/moe_gemm/moe_gemm_kernels_template.h
@@ -233,6 +233,57 @@ struct dispatch_stages {
 
 template<typename T,
          typename WeightType,
+         typename EpilogueTag,
+         typename ThreadblockShape,
+         typename WarpShape,
+         int Stages>
+struct dispatch_stages<T,
+                       WeightType,
+                       cutlass::arch::Sm90,
+                       EpilogueTag,
+                       ThreadblockShape,
+                       WarpShape,
+                       Stages,
+                       typename std::enable_if<(Stages > 2)>::type> {
+    static void dispatch(const T*          A,
+                         const WeightType* B,
+                         const T*          weight_scales,
+                         const T*          biases,
+                         T*                C,
+                         int64_t*          total_rows_before_expert,
+                         int64_t           gemm_n,
+                         int64_t           gemm_k,
+                         int               num_experts,
+                         CutlassGemmConfig gemm_config,
+                         int               multi_processor_count,
+                         cudaStream_t      stream,
+                         int*              occupancy = nullptr)
+    {
+        generic_moe_gemm_kernelLauncher<T,
+                                        WeightType,
+                                        cutlass::arch::Sm90,
+                                        EpilogueTag,
+                                        ThreadblockShape,
+                                        WarpShape,
+                                        Stages>(A,
+                                                B,
+                                                weight_scales,
+                                                biases,
+                                                C,
+                                                total_rows_before_expert,
+                                                gemm_n,
+                                                gemm_k,
+                                                num_experts,
+                                                gemm_config,
+                                                multi_processor_count,
+                                                stream,
+                                                occupancy);
+    }
+};
+
+
+template<typename T,
+         typename WeightType,
          typename arch,
          typename EpilogueTag,
          typename ThreadblockShape,
@@ -725,6 +776,27 @@ void MoeGemmRunner<T, V>::dispatch_to_arch<EpilogueTag>(const T*          A,
                                                                                       multi_processor_count_,
                                                                                       stream,
                                                                                       occupancy);
+    }
+    else if (sm_ >=90) {
+
+        dispatch_moe_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, EpilogueTag>(A, B, weight_scales, biases, C,
+            total_rows_before_expert, total_rows, gemm_n, gemm_k, num_experts, gemm_config, sm_, multi_processor_count_,
+            stream, occupancy);
+        //dispatch_moe_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm90, EpilogueTag>(A,
+        //                                                                              B,
+        //                                                                              weight_scales,
+        //                                                                              biases,
+        //                                                                              C,
+        //                                                                              total_rows_before_expert,
+        //                                                                              total_rows,
+        //                                                                              gemm_n,
+        //                                                                              gemm_k,
+        //                                                                              num_experts,
+        //                                                                              gemm_config,
+        //                                                                              sm_,
+        //                                                                              multi_processor_count_,
+        //                                                                              stream,
+        //                                                                              occupancy);
     }
     else {
         throw std::runtime_error("[FT Error][MoE][GEMM Dispatch] Arch unsupported for MoE GEMM");

--- a/dskernels/ft_gemm/gemm_variants/moe_gemm/moe_gemm_kernels_template.h
+++ b/dskernels/ft_gemm/gemm_variants/moe_gemm/moe_gemm_kernels_template.h
@@ -778,25 +778,20 @@ void MoeGemmRunner<T, V>::dispatch_to_arch<EpilogueTag>(const T*          A,
                                                                                       occupancy);
     }
     else if (sm_ >=90) {
-
-        dispatch_moe_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, EpilogueTag>(A, B, weight_scales, biases, C,
-            total_rows_before_expert, total_rows, gemm_n, gemm_k, num_experts, gemm_config, sm_, multi_processor_count_,
-            stream, occupancy);
-        //dispatch_moe_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm90, EpilogueTag>(A,
-        //                                                                              B,
-        //                                                                              weight_scales,
-        //                                                                              biases,
-        //                                                                              C,
-        //                                                                              total_rows_before_expert,
-        //                                                                              total_rows,
-        //                                                                              gemm_n,
-        //                                                                              gemm_k,
-        //                                                                              num_experts,
-        //                                                                              gemm_config,
-        //                                                                              sm_,
-        //                                                                              multi_processor_count_,
-        //                                                                              stream,
-        //                                                                              occupancy);
+        dispatch_moe_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, EpilogueTag>(A, 
+                                                                                      B, 
+                                                                                      weight_scales, 
+                                                                                      biases, 
+                                                                                      C,
+                                                                                      total_rows_before_expert, 
+                                                                                      total_rows, gemm_n, 
+                                                                                      gemm_k, 
+                                                                                      num_experts, 
+                                                                                      gemm_config, 
+                                                                                      sm_, 
+                                                                                      multi_processor_count_,
+                                                                                      stream, 
+                                                                                      occupancy);
     }
     else {
         throw std::runtime_error("[FT Error][MoE][GEMM Dispatch] Arch unsupported for MoE GEMM");


### PR DESCRIPTION
This PR adds the kernel support for running MoE models (like Mixtral) on H100.