### PR TITLE
Update actions to latest to resolve node.js warnings

### DIFF
--- a/.github/workflows/build-kernels.yml
+++ b/.github/workflows/build-kernels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, cpu]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     environment: release-env
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -47,7 +47,7 @@ jobs:
         run: |
           python release/bump_patch_version.py --current_version ${{ env.RELEASE_VERSION }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_PAT }}
           add-paths: |


### PR DESCRIPTION
GitHub is removing support for node 16, so we must move to versions of these actions that support node 20.
Corresponding change in DeepSpeed is here: https://github.com/microsoft/DeepSpeed/pull/5415